### PR TITLE
🚀 feat: implement graceful degradation for unsupported parameters (#5)

### DIFF
--- a/issues/issue_5.md
+++ b/issues/issue_5.md
@@ -1,0 +1,102 @@
+## Problem Statement
+
+LiteLLM connector is passing `temperature: 0.7` to an OpenAI model that only accepts the default temperature value of `1`. The OpenAI API rejects the request with a 400 Bad Request error, causing task failure.
+
+This suggests:
+- Model configuration does not validate OpenAI-specific parameter constraints before API call
+- Model parameter constraints are not documented or enforced client-side
+- User receives cryptic error instead of graceful fallback or validation
+
+---
+
+## Error Details
+
+```
+LiteLLM API error: 400 Bad Request
+litellm.BadRequestError: OpenAIException -
+Unsupported value: 'temperature' does not support 0.7 with this model.
+Only the default (1) value is supported.
+```
+
+---
+
+## Symptoms
+
+- Task fails with 400 Bad Request when temperature parameter is set
+- Error occurs when using specific OpenAI model(s)
+- No client-side validation prevents invalid parameter combinations
+- Wasted API quota on rejected requests
+
+---
+
+## Impact
+- Tasks fail unexpectedly with cryptic errors
+- Poor UX for users unfamiliar with OpenAI model constraints
+- Difficult to debug (error doesn't specify model name clearly)
+- No graceful fallback mechanism
+
+---
+
+## Acceptance Criteria
+
+- [ ] Identify which OpenAI model(s) reject temperature parameter
+- [ ] Document temperature constraints for affected OpenAI model(s)
+- [ ] Add client-side parameter validation before OpenAI API call
+- [ ] Implement graceful fallback (use default temperature or skip parameter)
+- [ ] Improve error messaging to specify model name & supported parameter range
+- [ ] Add configuration option to override parameter constraints (if intentional)
+- [ ] Unit tests for OpenAI parameter validation
+- [ ] Integration test with OpenAI API confirming valid requests succeed
+- [ ] Update connector docs with OpenAI model-specific parameter constraints
+
+---
+
+## Investigation Steps
+
+**For initial triage:**
+1. [ ] Identify which OpenAI model was being used when error occurred
+2. [ ] Check OpenAI API docs for temperature constraints on this model
+3. [ ] Verify LiteLLM's OpenAI model configuration matches API reality
+4. [ ] Determine if temperature should be removed or set to default (1)
+5. [ ] Check if other OpenAI models have similar constraints
+6. [ ] Review parameter validation logic for OpenAI provider in connector
+
+---
+
+## Suspected Root Causes
+
+- [ ] OpenAI model configuration missing temperature constraints
+- [ ] Parameter validation skipped or incomplete for OpenAI provider
+- [ ] Hardcoded temperature value (0.7) incompatible with OpenAI model
+- [ ] LiteLLM's OpenAI model definition out of sync with API behavior
+- [ ] No parameter override mechanism for OpenAI model-specific quirks
+
+---
+
+## Reproduction Steps
+
+```gherkin
+Given a task configured with temperature: 0.7
+And an OpenAI model that only supports temperature: 1
+When the connector sends the request to OpenAI API
+Then the request should succeed (use default or skip temperature)
+But currently: 400 Bad Request error from OpenAI
+```
+
+---
+
+## Solution Options (for discussion)
+
+| Option | Tradeoff |
+|--------|----------|
+| **Skip unsupported params** | Graceful, but user loses control |
+| **Use model default** | Safe, but may change model behavior |
+| **Validate & fail early** | Clear error, but blocks user |
+| **Config override** | Flexible, but complex configuration |
+| **Warn & fallback** | Best UX, requires logging |
+
+---
+
+## Related Links
+- [OpenAI API Parameter Docs](https://platform.openai.com/docs/api-reference)
+- [LiteLLM OpenAI Provider](https://docs.litellm.ai/docs/providers/openai)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"type": "git",
 		"url": "https://github.com/gethnet/litellm-vscode-chat"
 	},
-	"version": "1.0.3-dev",
+	"version": "1.0.4-dev",
 	"preview": true,
 	"engines": {
 		"vscode": "^1.107.0"
@@ -78,16 +78,18 @@
 		"@stylistic/eslint-plugin": "^2.9.0",
 		"@types/mocha": "^10.0.6",
 		"@types/node": "^22",
+		"@types/sinon": "^21.0.0",
 		"@types/vscode": "^1.104.0",
 		"@vscode/dts": "^0.4.1",
 		"@vscode/test-cli": "^0.0.11",
 		"@vscode/test-electron": "^2.5.2",
+		"@vscode/vsce": "^3.7.0",
 		"all-contributors-cli": "^6.26.1",
 		"eslint": "^9.13.0",
 		"prettier": "^3.1.0",
+		"sinon": "^21.0.1",
 		"typescript": "^5.9.2",
-		"typescript-eslint": "^8.39.0",
-		"@vscode/vsce": "^3.7.0"
+		"typescript-eslint": "^8.39.0"
 	},
 	"extensionDependencies": [
 		"github.copilot-chat"

--- a/src/test/unit/errorHandling.test.ts
+++ b/src/test/unit/errorHandling.test.ts
@@ -1,0 +1,186 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { LiteLLMChatModelProvider } from "../../providers/liteLLMProvider";
+import { LiteLLMClient } from "../../adapters/litellmClient";
+import * as sinon from "sinon";
+
+suite("LiteLLM Error Handling Unit Tests", () => {
+	const mockSecrets: vscode.SecretStorage = {
+		get: async (key: string) => {
+			if (key === "litellm-connector.baseUrl") {
+				return "http://localhost:4000";
+			}
+			if (key === "litellm-connector.apiKey") {
+				return "test-api-key";
+			}
+			return undefined;
+		},
+		store: async () => {},
+		delete: async () => {},
+		onDidChange: (_listener: unknown) => ({ dispose() {} }),
+	} as unknown as vscode.SecretStorage;
+
+	const userAgent = "GitHubCopilotChat/test VSCode/test";
+	let sandbox: sinon.SinonSandbox;
+
+	setup(() => {
+		sandbox = sinon.createSandbox();
+	});
+
+	teardown(() => {
+		sandbox.restore();
+	});
+
+	test("provideLanguageModelChatResponse retries without parameters on unsupported parameter error", async () => {
+		const provider = new LiteLLMChatModelProvider(mockSecrets, userAgent);
+
+		const errorText = JSON.stringify({
+			error: {
+				message: "Unsupported parameter: temperature",
+				type: "invalid_request_error",
+			},
+		});
+		const apiError = new Error(`LiteLLM API error: 400 Bad Request\n${errorText}`);
+
+		const chatStub = sandbox.stub(LiteLLMClient.prototype, "chat");
+		chatStub.onFirstCall().rejects(apiError);
+		chatStub.onSecondCall().resolves(
+			new ReadableStream({
+				start(controller) {
+					controller.enqueue(
+						new TextEncoder().encode('data: {"choices":[{"delta":{"content":"Success after retry"}}]}\n\n')
+					);
+					controller.close();
+				},
+			})
+		);
+
+		const model: vscode.LanguageModelChatInformation = {
+			id: "test-model",
+			name: "Test Model",
+			family: "litellm",
+			version: "1.0.0",
+			maxInputTokens: 4096,
+			maxOutputTokens: 1024,
+			capabilities: { toolCalling: true, imageInput: false },
+			tooltip: "test",
+		};
+
+		const messages = [new vscode.LanguageModelChatMessage(vscode.LanguageModelChatMessageRole.User, "Hello")];
+
+		const options: vscode.ProvideLanguageModelChatResponseOptions = {
+			modelOptions: { temperature: 0.5 },
+			toolMode: vscode.LanguageModelChatToolMode.Auto,
+		};
+
+		const reportedParts: vscode.LanguageModelResponsePart[] = [];
+		const progress: vscode.Progress<vscode.LanguageModelResponsePart> = {
+			report: (part) => reportedParts.push(part),
+		};
+
+		await provider.provideLanguageModelChatResponse(
+			model,
+			messages,
+			options,
+			progress,
+			new vscode.CancellationTokenSource().token
+		);
+
+		assert.strictEqual(chatStub.callCount, 2);
+		// Check that the second call didn't have temperature
+		const secondCallArgs = chatStub.getCall(1).args[0];
+		assert.strictEqual(secondCallArgs.temperature, undefined);
+
+		const textParts = reportedParts.filter((p) => p instanceof vscode.LanguageModelTextPart);
+		assert.ok(textParts.some((p) => p.value === "Success after retry"));
+	});
+
+	test("provideLanguageModelChatResponse handles unsupported parameter error from LiteLLM (when retry also fails)", async () => {
+		const provider = new LiteLLMChatModelProvider(mockSecrets, userAgent);
+
+		// Mock LiteLLMClient.chat to throw an error
+		const errorText = JSON.stringify({
+			error: {
+				message: "Unsupported parameter: temperature",
+				type: "invalid_request_error",
+				param: "temperature",
+				code: "unsupported_parameter",
+			},
+		});
+		const apiError = new Error(`LiteLLM API error: 400 Bad Request\n${errorText}`);
+
+		sandbox.stub(LiteLLMClient.prototype, "chat").rejects(apiError);
+
+		const model: vscode.LanguageModelChatInformation = {
+			id: "test-model",
+			name: "Test Model",
+			family: "litellm",
+			version: "1.0.0",
+			maxInputTokens: 4096,
+			maxOutputTokens: 1024,
+			capabilities: { toolCalling: true, imageInput: false },
+			tooltip: "test",
+		};
+
+		const messages = [new vscode.LanguageModelChatMessage(vscode.LanguageModelChatMessageRole.User, "Hello")];
+
+		const options: vscode.ProvideLanguageModelChatResponseOptions = {
+			modelOptions: { temperature: 0.5 },
+			toolMode: vscode.LanguageModelChatToolMode.Auto, // LanguageModelChatToolMode.Auto
+		};
+
+		const progress: vscode.Progress<vscode.LanguageModelResponsePart> = {
+			report: () => {},
+		};
+
+		const token = new vscode.CancellationTokenSource().token;
+
+		try {
+			await provider.provideLanguageModelChatResponse(model, messages, options, progress, token);
+			assert.fail("Should have thrown an error");
+		} catch (err) {
+			const error = err as Error;
+			assert.ok(error.message.includes("LiteLLM Error (test-model)"));
+			assert.ok(error.message.includes("Unsupported parameter: temperature"));
+			assert.ok(error.message.includes("This model may not support certain parameters like temperature"));
+		}
+	});
+
+	test("provideLanguageModelChatResponse handles generic 400 error", async () => {
+		const provider = new LiteLLMChatModelProvider(mockSecrets, userAgent);
+
+		const apiError = new Error(`LiteLLM API error: 400 Bad Request\nSomething went wrong`);
+		sandbox.stub(LiteLLMClient.prototype, "chat").rejects(apiError);
+
+		const model: vscode.LanguageModelChatInformation = {
+			id: "test-model",
+			name: "Test Model",
+			family: "litellm",
+			version: "1.0.0",
+			maxInputTokens: 4096,
+			maxOutputTokens: 1024,
+			capabilities: { toolCalling: true, imageInput: false },
+			tooltip: "test",
+		};
+
+		const progress: vscode.Progress<vscode.LanguageModelResponsePart> = {
+			report: () => {},
+		};
+
+		try {
+			const dummyMessages = [new vscode.LanguageModelChatMessage(vscode.LanguageModelChatMessageRole.User, "Hello")];
+			await provider.provideLanguageModelChatResponse(
+				model,
+				dummyMessages,
+				{ toolMode: vscode.LanguageModelChatToolMode.Auto },
+				progress,
+				new vscode.CancellationTokenSource().token
+			);
+			assert.fail("Should have thrown an error");
+		} catch (err) {
+			const error = err as Error;
+			assert.ok(error.message.includes("LiteLLM Error (test-model)"));
+			assert.ok(error.message.includes("Something went wrong"));
+		}
+	});
+});

--- a/src/test/unit/provider.test.ts
+++ b/src/test/unit/provider.test.ts
@@ -102,4 +102,32 @@ suite("LiteLLM Provider Unit Tests", () => {
 		assert.strictEqual(requestBody.frequency_penalty, undefined);
 		assert.deepStrictEqual(requestBody.stop, ["\n"]);
 	});
+
+	test("stripUnsupportedParametersFromRequest handles o1 models", () => {
+		const provider = new LiteLLMChatModelProvider(mockSecrets, userAgent);
+		const strip = (
+			provider as unknown as {
+				stripUnsupportedParametersFromRequest: (
+					requestBody: Record<string, unknown>,
+					modelInfo: unknown,
+					modelId?: string
+				) => void;
+			}
+		).stripUnsupportedParametersFromRequest.bind(provider);
+
+		const requestBody: Record<string, unknown> = {
+			temperature: 1.0,
+			top_p: 1.0,
+			presence_penalty: 0.0,
+			max_tokens: 1000,
+		};
+
+		// o1 models shouldn't have temperature, top_p, or penalties
+		strip(requestBody, undefined, "o1-mini");
+
+		assert.strictEqual(requestBody.temperature, undefined);
+		assert.strictEqual(requestBody.top_p, undefined);
+		assert.strictEqual(requestBody.presence_penalty, undefined);
+		assert.strictEqual(requestBody.max_tokens, 1000);
+	});
 });


### PR DESCRIPTION
- Added automatic retry mechanism in LiteLLMChatModelProvider to strip optional parameters (temperature, top_p, etc.) if the LiteLLM API returns an "unsupported parameter" error.
- Expanded KNOWN_PARAMETER_LIMITATIONS to include o1-preview, o1-mini, and other o1- models.
- Improved error parsing and user-friendly messaging for API errors.
- Added comprehensive unit tests in errorHandling.test.ts to verify retry logic and error handling.
- Integrated sinon for robust test mocking.
- Resolved linting issues and updated package.json dependencies.